### PR TITLE
tools/Makefile.in: add a couple missing $(EXEEXT) suffixes

### DIFF
--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -672,8 +672,8 @@ all: encodings.h
 encodings.sed: $(top_builddir)/iconvenc.h
 	sed -e 's/^#define \([A-Z0-9_]*\) \(.*\)/@\1@ \2/' -e 's/"//g' -e 's/NULL$$//' -e 's/ /\//' -e 's/^\(.*\)$$/s\/\1\//' $(top_builddir)/iconvenc.h >encodings.sed
 
-encodings.h: encodings.sed $(srcdir)/encodings.dat make_hash
-	sed -f encodings.sed $(srcdir)/encodings.dat | ./make_hash >encodings.h
+encodings.h: encodings.sed $(srcdir)/encodings.dat make_hash$(EXEEXT)
+	sed -f encodings.sed $(srcdir)/encodings.dat | ./make_hash$(EXEEXT) >encodings.h
 
 @MAINTAINER_MODE_TRUE@tables: $(TABLES) $(TABLES_INCR)
 


### PR DESCRIPTION
Without these, MinGW-w64 fails to build the tooling on Linux, as shown below.

```
$ CPPFLAGS="-march=core2" ../../configure --prefix=/usr/x86_64-w64-mingw32 --disable-shared --enable-silent-rules --host=x86_64-w64-mingw32 && make
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for x86_64-w64-mingw32-strip... x86_64-w64-mingw32-strip
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether to enable maintainer-specific portions of Makefiles... no
checking for gawk... (cached) gawk
checking for x86_64-w64-mingw32-gcc... x86_64-w64-mingw32-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.exe
checking for suffix of executables... .exe
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether x86_64-w64-mingw32-gcc accepts -g... yes
checking for x86_64-w64-mingw32-gcc option to accept ISO C89... none needed
checking whether x86_64-w64-mingw32-gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of x86_64-w64-mingw32-gcc... gcc3
checking how to run the C preprocessor... x86_64-w64-mingw32-gcc -E
checking build system type... x86_64-pc-linux-gnu
checking for x86_64-pc-linux-gnu-gcc... no
checking for gcc... gcc
checking whether we are using the GNU C compiler... (cached) yes
../../configure: line 4654: test: =: unary operator expected
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for library containing strerror... none required
checking host system type... x86_64-w64-mingw32
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for fgrep... /usr/bin/grep -F
checking for ld used by x86_64-w64-mingw32-gcc... /usr/x86_64-w64-mingw32/bin/ld
checking if the linker (/usr/x86_64-w64-mingw32/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/x86_64-w64-mingw32-nm -B
checking the name lister (/usr/bin/x86_64-w64-mingw32-nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-w64-mingw32 format... func_convert_file_nix_to_w32
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/x86_64-w64-mingw32/bin/ld option to reload object files... -r
checking for x86_64-w64-mingw32-objdump... x86_64-w64-mingw32-objdump
checking how to recognize dependent libraries... file_magic ^x86 archive import|^x86 DLL
checking for x86_64-w64-mingw32-dlltool... x86_64-w64-mingw32-dlltool
checking how to associate runtime and link libraries... func_cygming_dll_for_implib
checking for x86_64-w64-mingw32-ar... x86_64-w64-mingw32-ar
checking for archiver @FILE support... @
checking for x86_64-w64-mingw32-strip... (cached) x86_64-w64-mingw32-strip
checking for x86_64-w64-mingw32-ranlib... x86_64-w64-mingw32-ranlib
checking command to parse /usr/bin/x86_64-w64-mingw32-nm -B output from x86_64-w64-mingw32-gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for x86_64-w64-mingw32-mt... no
checking for mt... mt
checking if mt is a manifest tool... no
checking for dlfcn.h... no
checking for objdir... .libs
checking if x86_64-w64-mingw32-gcc supports -fno-rtti -fno-exceptions... no
checking for x86_64-w64-mingw32-gcc option to produce PIC... -DDLL_EXPORT -DPIC
checking if x86_64-w64-mingw32-gcc PIC flag -DDLL_EXPORT -DPIC works... yes
checking if x86_64-w64-mingw32-gcc static flag -static works... yes
checking if x86_64-w64-mingw32-gcc supports -c -o file.o... yes
checking if x86_64-w64-mingw32-gcc supports -c -o file.o... (cached) yes
checking whether the x86_64-w64-mingw32-gcc linker (/usr/x86_64-w64-mingw32/bin/ld) supports shared libraries... yes
checking dynamic linker characteristics... Win32 ld.exe
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking for x86_64-w64-mingw32-gcc... (cached) x86_64-w64-mingw32-gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether x86_64-w64-mingw32-gcc accepts -g... (cached) yes
checking for x86_64-w64-mingw32-gcc option to accept ISO C89... (cached) none needed
checking whether x86_64-w64-mingw32-gcc understands -c and -o together... (cached) yes
checking dependency style of x86_64-w64-mingw32-gcc... (cached) gcc3
checking whether ln -s works... yes
checking for mktemp... /usr/bin/mktemp
checking for cstocs... no
checking for recode... no
checking for umap... no
checking for piconv... /usr/bin/piconv
checking for map... no
checking for gcov... /usr/bin/gcov
checking for gtkdoc-mkdb... true
checking gtk-doc version (1.33.1) >= 1.0... no
checking for sqrt in -lm... yes
checking for ANSI C header files... (cached) yes
checking for sys/wait.h that is POSIX.1 compatible... no
checking whether time.h and sys/time.h may both be included... yes
checking whether stat file-mode macros are broken... no
checking for stdbool.h that conforms to C99... yes
checking for _Bool... yes
checking errno.h usability... yes
checking errno.h presence... yes
checking for errno.h... yes
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking getopt.h usability... yes
checking getopt.h presence... yes
checking for getopt.h... yes
checking langinfo.h usability... no
checking langinfo.h presence... no
checking for langinfo.h... no
checking limits.h usability... yes
checking limits.h presence... yes
checking for limits.h... yes
checking locale.h usability... yes
checking locale.h presence... yes
checking for locale.h... yes
checking for memory.h... (cached) yes
checking for string.h... (cached) yes
checking for strings.h... (cached) yes
checking for sys/stat.h... (cached) yes
checking for sys/types.h... (cached) yes
checking for sys/wait.h... (cached) no
checking sys/time.h usability... yes
checking sys/time.h presence... yes
checking for sys/time.h... yes
checking time.h usability... yes
checking time.h presence... yes
checking for time.h... yes
checking for unistd.h... (cached) yes
checking wordexp.h usability... no
checking wordexp.h presence... no
checking for wordexp.h... no
checking for an ANSI C-conforming const... yes
checking for size_t... yes
checking for mode_t... yes
checking for off_t... yes
checking for pid_t... yes
checking for uid_t in sys/types.h... no
checking for ssize_t... yes
checking whether LC_MESSAGES is declared... no
checking for program_invocation_short_name... no
checking vfork.h usability... no
checking vfork.h presence... no
checking for vfork.h... no
checking for fork... no
checking for vfork... no
checking for ftruncate... yes
checking for gettimeofday... yes
checking for isatty... yes
checking for nl_langinfo... no
checking for random... no
checking for realpath... no
checking for strstr... yes
checking for stpcpy... no
checking for setlocale... yes
checking for ttyname... no
checking for wordexp... no
checking for getopt_long... yes
checking for ld used by x86_64-w64-mingw32-gcc... /usr/x86_64-w64-mingw32/bin/ld
checking if the linker (/usr/x86_64-w64-mingw32/bin/ld) is GNU ld... yes
checking for shared library run path origin... done
checking for iconv... yes
checking for working iconv... yes
checking how to link with libiconv... -liconv
checking for iconv declaration... 
         extern size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
checking whether iconv implementation is usable... no
checking for recode_new_outer in librecode... no
checking for locale.alias... /usr/share/locale/locale.alias
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating enca.spec
config.status: creating enca.pc
config.status: creating devel-docs/Makefile
config.status: creating data/Makefile
config.status: creating lib/Makefile
config.status: creating script/Makefile
config.status: creating script/b-cstocs
config.status: creating script/b-map
config.status: creating script/b-piconv
config.status: creating script/b-umap
config.status: creating src/Makefile
config.status: creating src/HELP
config.status: creating test/Makefile
config.status: creating tools/Makefile
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
=================================================================
  Features:
    libenca will be built as:            static
    GNU recode library interface:        no
    UNIX98 iconv interface:              no
    (consider installing at least one of GNU libiconv and GNU librecode)
    External converters:                 no
    Language preferences from locale:    yes
    Language aliases decryption:         /usr/share/locale/locale.alias
    Target charset from locale:          no
    ENCAOPT environment variable:        built-in parser (naive)
=================================================================

Configure complete, now type `make' to compile enca.
If it compiles, don't forget to run `make check'.
make  all-recursive
make[1]: Entering directory '/home/qyot27/mpv-build-deps/enca/enca-build/amd64'
Making all in tools
make[2]: Entering directory '/home/qyot27/mpv-build-deps/enca/enca-build/amd64/tools'
sed -e 's/^#define \([A-Z0-9_]*\) \(.*\)/@\1@ \2/' -e 's/"//g' -e 's/NULL$//' -e 's/ /\//' -e 's/^\(.*\)$/s\/\1\//' ../iconvenc.h >encodings.sed
x86_64-w64-mingw32-gcc -Wall -Wextra -W -pedantic -g -O2 -march=core2   ../../../tools/make_hash.c   -o make_hash
sed -f encodings.sed ../../../tools/encodings.dat | ./make_hash >encodings.h
/bin/bash: line 1: ./make_hash: No such file or directory
make[2]: *** [Makefile:676: encodings.h] Error 127
make[2]: Leaving directory '/home/qyot27/mpv-build-deps/enca/enca-build/amd64/tools'
make[1]: *** [Makefile:565: all-recursive] Error 1
make[1]: Leaving directory '/home/qyot27/mpv-build-deps/enca/enca-build/amd64'
make: *** [Makefile:429: all] Error 2
```