### PR TITLE
t59: Removed build error and warning for mingw gcc compiler on windows #59. 

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -213,9 +213,8 @@ int         check_external_converter (void);
 #endif /* ENABLE_EXTERNAL */
 
 char*       detect_lang            (const char *lang);
-#ifdef HAVE_NL_LANGINFO
+
 const char* get_lang_codeset       (void);
-#endif /* HAVE_NL_LANGINFO */
 
 #endif /* not COMMON_H */
 /* vim: ts=2

--- a/src/convert_extern.c
+++ b/src/convert_extern.c
@@ -64,7 +64,7 @@ convert_external(File *file,
 
   pid_t pid;
   int status;
-  File *tempfile = NULL;
+  File *volatile tempfile = NULL;
   char *from_name, *target_name;
 
   if (*extern_converter == '\0') {

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -148,11 +148,11 @@ extern int getopt ();
 # endif /* __GNU_LIBRARY__ */
 
 # ifndef __need_getopt
-extern int getopt_long (int __argc, char *const *__argv, const char *__shortopts,
-		        const struct option *__longopts, int *__longind);
-extern int getopt_long_only (int __argc, char *const *__argv,
-			     const char *__shortopts,
-		             const struct option *__longopts, int *__longind);
+extern int getopt_long (int argc, char *const *argv, const char *shortopts,
+		        const struct option *longopts, int *longind);
+extern int getopt_long_only (int argc, char *const *argv,
+			     const char *shortopts,
+		             const struct option *longopts, int *longind);
 
 /* Internal only.  Users should not call this directly.  */
 extern int _getopt_internal (int __argc, char *const *__argv,


### PR DESCRIPTION
1. Fixed function prototype ```getopt_long``` and ```getopt_long_only which cause error on windows clang and gcc.  The prototypes parameter matched a define in stdlib.h
```c
#define __argc (* __p___argc())
#define __argv (* __p___argv())
```
2. Fixed a warning of missing prototype of ```get_lang_codeset```.
3. Fixed a warning​ ```  warning: variable ‘tempfile’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]```