### PR TITLE
Release 1.20

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 #============================================================================
-# Enca v1.20 (2016-09-05)  guess and convert encoding of text files
+# Enca v1.20 (2025-07-21)  guess and convert encoding of text files
 # Copyright (C) 2000-2003 David Necas (Yeti) <yeti@physics.muni.cz>
 # Copyright (C) 2009-2016 Michal Cihar <michal@cihar.com>
 #============================================================================
@@ -21,6 +21,7 @@ enca-1.20
   + add support for testing on MSYS2 MINGW
   - fixed normalize.pl input format.
   + add usage help to normalize.pl and countall
+
 enca-1.19 2016-09-05
   - fix possible memory leak
   - make utf-8 detection work even on one character

--- a/FAQ
+++ b/FAQ
@@ -1,5 +1,5 @@
 #============================================================================
-# Enca v1.20 (2016-09-05)  guess and convert encoding of text files
+# Enca v1.20 (2025-07-21)  guess and convert encoding of text files
 # Copyright (C) 2000-2003 David Necas (Yeti) <yeti@physics.muni.cz>
 # Copyright (C) 2009-2016 Michal Cihar <michal@cihar.com>
 #============================================================================

--- a/TODO
+++ b/TODO
@@ -1,5 +1,5 @@
 #============================================================================
-# Enca v1.20 (2016-09-05)  guess and convert encoding of text files
+# Enca v1.20 (2025-07-21)  guess and convert encoding of text files
 # Copyright (C) 2000-2003 David Necas (Yeti) <yeti@physics.muni.cz>
 # Copyright (C) 2009-2016 Michal Cihar <michal@cihar.com>
 #============================================================================


### PR DESCRIPTION
enca-1.20
  - fix crosscompilation issues
  - fix documentation build
  - fix compiler warnings
  - fix librecode detection
  - fix normalize.py input format
  - with --disable-gtk-doc docs are not installed
  - add support for testing on MSYS2 MINGW
  - fixed normalize.pl input format.
  - add usage help to normalize.pl and countall