### PR TITLE
Add Finnish language to man page

### DIFF
--- a/man/enca.1
+++ b/man/enca.1
@@ -672,6 +672,7 @@ Belarusian @CP1251 IBM866 ISO\-8859\-5 KOI8\-UNI maccyr IBM855
 Bulgarian  @CP1251 ISO\-8859\-5 IBM855 maccyr ECMA\-113
 Czech      @ISO\-8859\-2 CP1250 IBM852 KEYBCS2 macce KOI\-8_CS_2 CORK
 Estonian   @ISO\-8859\-4 CP1257 IBM775 ISO\-8859\-13 macce baltic
+Finnish    @ISO\-8859\-4 CP1257
 Croatian   @CP1250 ISO\-8859\-2 IBM852 macce CORK
 Hungarian  @ISO\-8859\-2 CP1250 IBM852 macce CORK
 Lithuanian @CP1257 ISO\-8859\-4 IBM775 ISO\-8859\-13 macce baltic
@@ -696,6 +697,7 @@ Belarusian   @be
 Bulgarian    @bg
 Czech        @cs
 Estonian     @et
+Finnish      @fi
 Croatian     @hr
 Hungarian    @hu
 Lithuanian   @lt


### PR DESCRIPTION
This update adds Finnish (fi) to the list of supported languages in the Enca manual (man/enca.1). The Finnish language and its associated encodings (ISO-8859-4, CP1257) are now documented alongside other supported languages.

