### PR TITLE
Add --without-iconv configure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Optional features:
   then searched in DIR/include and the library itself in DIR/lib.
 
 * Compilation of UNIX98 iconv interface is controlled by
-  `--with-iconv[=DIR]`, `--without-iconv`
+  `--with-libiconv[=DIR]`, `--without-libiconv`
   configure parameters.  It is compiled in by default when found
-  and considered usable.  Optionally, you can specify a DIR; iconv
+  and considered usable.  Optionally, you can specify a DIR; libiconv
   include files will be then searched in DIR/include and the library
-  itself in DIR/lib.  Additionally, `--with-libiconv-prefix[=DIR]` and
-  `--without-libiconv-prefix` can be used to control the search path
-  for external libiconv library.
+  itself in DIR/lib. (The legacy `--with-iconv`/`--without-iconv` options
+  are still accepted for backward compatibility, but may be removed in a
+  future release.)
 
 * Compilation of interface to external converter programs is controlled by
   `--enable-external`, `--disable-external`

--- a/configure
+++ b/configure
@@ -832,6 +832,7 @@ enable_external
 with_gcov
 with_html_dir
 enable_gtk_doc
+with_libiconv
 with_iconv
 enable_rpath
 with_libiconv_prefix
@@ -1505,8 +1506,8 @@ Optional Packages:
                           compiler's sysroot if not specified).
   --with-gcov           compile for coverage tests using gcov (default=no)
   --with-html-dir=PATH    path to installed docs [DATADIR/gtk-doc/html]
-  --with-iconv[=DIR]      look for iconv in DIR/lib and DIR/include [auto]
-  --without-iconv           disable iconv interface
+  --with-libiconv[=DIR]  look for libiconv in DIR/lib and DIR/include [auto]\n  --without-libiconv        disable libiconv (UNIX98 iconv) interface
+
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
   --with-libiconv-prefix[=DIR]  search for libiconv in DIR/include and DIR/lib
   --without-libiconv-prefix     don't search for libiconv in includedir and libdir
@@ -18529,75 +18530,107 @@ printf "%s\n" "#define ICONV_CONST $am_cv_proto_iconv_arg1" >>confdefs.h
 
 
 
+# ----------------------------------------------------------------------------
+# Option handling for libiconv (UNIX98 iconv interface)
+# New (preferred) interface: --with-libiconv[=DIR] / --without-libiconv
+# Backwards compatible (deprecated) interface: --with-iconv[=DIR] / --without-iconv
+# DIR, when provided, adds DIR/include to CPPFLAGS and DIR/lib to LDFLAGS.
+# ----------------------------------------------------------------------------
+
+# Check whether --with-libiconv was given.
+if test ${with_libiconv+y}
+then :
+  withval=$with_libiconv; case "$withval" in
+    yes|auto) WANT_LIBICONV=1 ;;
+    no)       WANT_LIBICONV=0 ;;
+    *)        WANT_LIBICONV=1 ; yeti_libiconv_CPPFLAGS="-I$withval/include" ; yeti_libiconv_LDFLAGS="-L$withval/lib" ;;
+   esac
+   WANT_LIBICONV_SET=1
+else $as_nop
+  WANT_LIBICONV=1
+fi
+
+
+# Deprecated legacy option name --with-iconv. Use only if new one not specified.
 
 # Check whether --with-iconv was given.
 if test ${with_iconv+y}
 then :
-  withval=$with_iconv; case "$withval" in
-    yes|auto) WANT_ICONV=1 ;;
-    no)  WANT_ICONV=0 ;;
-    *)   WANT_ICONV=1 ;;
-    esac
-else $as_nop
-  WANT_ICONV=1
+  withval=$with_iconv; if test -z "$WANT_LIBICONV_SET"; then
+     case "$withval" in
+       yes|auto) WANT_LIBICONV=1 ;;
+       no)       WANT_LIBICONV=0 ;;
+       *)        WANT_LIBICONV=1 ; yeti_libiconv_CPPFLAGS="-I$withval/include" ; yeti_libiconv_LDFLAGS="-L$withval/lib" ;;
+     esac
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Option --with-iconv is deprecated, use --with-libiconv instead" >&5
+printf "%s\n" "$as_me: WARNING: Option --with-iconv is deprecated, use --with-libiconv instead" >&2;}
+   fi
 fi
 
 
-if test "$WANT_ICONV" = 1; then
+if test "$WANT_LIBICONV" = 1; then
+  # Apply custom include/lib dirs if requested before detection.
+  if test -n "$yeti_libiconv_CPPFLAGS"; then
+    CPPFLAGS="$CPPFLAGS $yeti_libiconv_CPPFLAGS"
+  fi
+  if test -n "$yeti_libiconv_LDFLAGS"; then
+    LDFLAGS="$LDFLAGS $yeti_libiconv_LDFLAGS"
+  fi
 
-CONVERTER_LIBS="$CONVERTER_LIBS $LIBICONV"
 
-libiconv_ok="$am_cv_func_iconv"
-if test "$libiconv_ok" = yes; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether iconv implementation is usable" >&5
+  CONVERTER_LIBS="$CONVERTER_LIBS $LIBICONV"
+
+          libiconv_ok="$am_cv_func_iconv"
+  if test "$libiconv_ok" = yes; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether iconv implementation is usable" >&5
 printf %s "checking whether iconv implementation is usable... " >&6; }
-  if $CC -o iconvcap$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS $srcdir/iconvcap.c $LIBS $CONVERTER_LIBS 1>&5 2>&5 && test -s ./iconvcap$ac_exeext 2>&5; then
-    if ./iconvcap 2>&5 >iconvenc.h; then
-      libiconv_ok=yes
+    if $CC -o iconvcap$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS $srcdir/iconvcap.c $LIBS $CONVERTER_LIBS 1>&5 2>&5 && test -s ./iconvcap$ac_exeext 2>&5; then
+      if ./iconvcap 2>&5 >iconvenc.h; then
+        libiconv_ok=yes
+      else
+        libiconv_ok=no
+      fi
     else
       libiconv_ok=no
     fi
-  else
-    libiconv_ok=no
-  fi
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $libiconv_ok" >&5
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $libiconv_ok" >&5
 printf "%s\n" "$libiconv_ok" >&6; }
-  if test "$libiconv_ok" = yes; then
+    if test "$libiconv_ok" = yes; then
 
 printf "%s\n" "#define HAVE_GOOD_ICONV 1" >>confdefs.h
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether iconv is transitive" >&5
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether iconv is transitive" >&5
 printf %s "checking whether iconv is transitive... " >&6; }
 if test ${yeti_cv_lib_c_iconv_transitive+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
   if ./iconvcap iconvenc.h 2>&5; then
-        yeti_cv_lib_c_iconv_transitive=yes
-      else
-        yeti_cv_lib_c_iconv_transitive=no
-      fi
+          yeti_cv_lib_c_iconv_transitive=yes
+        else
+          yeti_cv_lib_c_iconv_transitive=no
+        fi
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $yeti_cv_lib_c_iconv_transitive" >&5
 printf "%s\n" "$yeti_cv_lib_c_iconv_transitive" >&6; }
-    if test "$yeti_cv_lib_c_iconv_transitive" = yes; then
+      if test "$yeti_cv_lib_c_iconv_transitive" = yes; then
 
 printf "%s\n" "#define ICONV_IS_TRANSITIVE 1" >>confdefs.h
 
-    else
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: A non-transitive but otherwise usable iconv implementation
-                    was found.  This beast was believed to be mythical.
-                    Please send your system specs to the maintainer." >&5
+      else
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: A non-transitive but otherwise usable iconv implementation
+                      was found.  This beast was believed to be mythical.
+                      Please send your system specs to the maintainer." >&5
 printf "%s\n" "$as_me: WARNING: A non-transitive but otherwise usable iconv implementation
-                    was found.  This beast was believed to be mythical.
-                    Please send your system specs to the maintainer." >&2;}
+                      was found.  This beast was believed to be mythical.
+                      Please send your system specs to the maintainer." >&2;}
+      fi
+    else
+      echo >iconvenc.h
     fi
   else
-    echo >iconvenc.h
+    libiconv_ok=no
   fi
-else
-  libiconv_ok=no
-fi
 
 else
     libiconv_ok=no

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,7 @@ CONVERTER_LIBS=
 ye_CHECK_FUNC_ICONV_USABLE
 ye_CHECK_LIB_RECODE
 
+dnl Adjust default converter list preference order: prefer librecode, then libiconv
 DEFAULT_CONVERTER_LIST="built-in"
 if test "$librecode_ok" = "yes"; then
   DEFAULT_CONVERTER_LIST="$DEFAULT_CONVERTER_LIST,librecode"

--- a/m4/libiconv.m4
+++ b/m4/libiconv.m4
@@ -14,66 +14,90 @@ AC_DEFUN([ye_CHECK_FUNC_ICONV_USABLE],
 [AC_REQUIRE([AC_PROG_CC])dnl
 AC_REQUIRE([AC_HEADER_STDC])dnl
 AC_REQUIRE([AC_C_CONST])dnl
-dnl
 
-dnl Add configure option to disable iconv
-AC_ARG_WITH(iconv,
-  [  --with-iconv@<:@=DIR@:>@      look for iconv in DIR/lib and DIR/include @<:@auto@:>@
-  --without-iconv           disable iconv interface],
+# ----------------------------------------------------------------------------
+# Option handling for libiconv (UNIX98 iconv interface)
+# New (preferred) interface: --with-libiconv[=DIR] / --without-libiconv
+# Backwards compatible (deprecated) interface: --with-iconv[=DIR] / --without-iconv
+# DIR, when provided, adds DIR/include to CPPFLAGS and DIR/lib to LDFLAGS.
+# ----------------------------------------------------------------------------
+AC_ARG_WITH([libiconv],
+  [  --with-libiconv@<:@=DIR@:>@  look for libiconv in DIR/lib and DIR/include @<:@auto@:>@\n  --without-libiconv        disable libiconv (UNIX98 iconv) interface],
   [case "$withval" in
-    yes|auto) WANT_ICONV=1 ;;
-    no)  WANT_ICONV=0 ;;
-    *)   WANT_ICONV=1 ;;
-    esac],
-  [WANT_ICONV=1])
+    yes|auto) WANT_LIBICONV=1 ;;
+    no)       WANT_LIBICONV=0 ;;
+    *)        WANT_LIBICONV=1 ; yeti_libiconv_CPPFLAGS="-I$withval/include" ; yeti_libiconv_LDFLAGS="-L$withval/lib" ;;
+   esac
+   WANT_LIBICONV_SET=1],
+  [WANT_LIBICONV=1])
 
-if test "$WANT_ICONV" = 1; then
-dnl Use standard iconv test
-AM_ICONV
-CONVERTER_LIBS="$CONVERTER_LIBS $LIBICONV"
+# Deprecated legacy option name --with-iconv. Use only if new one not specified.
+AC_ARG_WITH([iconv],
+  [],
+  [if test -z "$WANT_LIBICONV_SET"; then
+     case "$withval" in
+       yes|auto) WANT_LIBICONV=1 ;;
+       no)       WANT_LIBICONV=0 ;;
+       *)        WANT_LIBICONV=1 ; yeti_libiconv_CPPFLAGS="-I$withval/include" ; yeti_libiconv_LDFLAGS="-L$withval/lib" ;;
+     esac
+     AS_WARN([Option --with-iconv is deprecated, use --with-libiconv instead])
+   fi])
 
-dnl Compile iconvcap.c and run it to determine what encodings iconv actually
-dnl knows an under what names. This is not needed with GNU iconv. HAVE_ICONV
-dnl is finally defined _only_ if iconv prove at least some minimal reasonable
-dnl capabilities.
-libiconv_ok="$am_cv_func_iconv"
-if test "$libiconv_ok" = yes; then
-  AC_MSG_CHECKING([whether iconv implementation is usable])
-  if $CC -o iconvcap$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS $srcdir/iconvcap.c $LIBS $CONVERTER_LIBS 1>&5 2>&5 && test -s ./iconvcap$ac_exeext 2>&5; then
-    if ./iconvcap 2>&5 >iconvenc.h; then
-      libiconv_ok=yes
+if test "$WANT_LIBICONV" = 1; then
+  # Apply custom include/lib dirs if requested before detection.
+  if test -n "$yeti_libiconv_CPPFLAGS"; then
+    CPPFLAGS="$CPPFLAGS $yeti_libiconv_CPPFLAGS"
+  fi
+  if test -n "$yeti_libiconv_LDFLAGS"; then
+    LDFLAGS="$LDFLAGS $yeti_libiconv_LDFLAGS"
+  fi
+
+  dnl Use standard iconv test (AM_ICONV comes from gettext infrastructure)
+  AM_ICONV
+  CONVERTER_LIBS="$CONVERTER_LIBS $LIBICONV"
+
+  dnl Compile iconvcap.c and run it to determine what encodings iconv actually
+  dnl knows and under what names. This is not needed with GNU iconv. HAVE_ICONV
+  dnl is finally defined _only_ if iconv proves at least some minimal reasonable
+  dnl capabilities.
+  libiconv_ok="$am_cv_func_iconv"
+  if test "$libiconv_ok" = yes; then
+    AC_MSG_CHECKING([whether iconv implementation is usable])
+    if $CC -o iconvcap$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS $srcdir/iconvcap.c $LIBS $CONVERTER_LIBS 1>&5 2>&5 && test -s ./iconvcap$ac_exeext 2>&5; then
+      if ./iconvcap 2>&5 >iconvenc.h; then
+        libiconv_ok=yes
+      else
+        libiconv_ok=no
+      fi
     else
       libiconv_ok=no
+    fi
+    AC_MSG_RESULT($libiconv_ok)
+    if test "$libiconv_ok" = yes; then
+      AC_DEFINE(HAVE_GOOD_ICONV,1,[Define if you have the UNIX98 iconv functions.])
+      AC_CACHE_CHECK([whether iconv is transitive],
+        yeti_cv_lib_c_iconv_transitive,
+        if ./iconvcap iconvenc.h 2>&5; then
+          yeti_cv_lib_c_iconv_transitive=yes
+        else
+          yeti_cv_lib_c_iconv_transitive=no
+        fi)
+      if test "$yeti_cv_lib_c_iconv_transitive" = yes; then
+        AC_DEFINE(ICONV_IS_TRANSITIVE,1,[Define if iconv is transitive.])
+      else
+        AC_MSG_WARN([A non-transitive but otherwise usable iconv implementation
+                      was found.  This beast was believed to be mythical.
+                      Please send your system specs to the maintainer.])
+      fi
+    else
+      echo >iconvenc.h
     fi
   else
     libiconv_ok=no
   fi
-  AC_MSG_RESULT($libiconv_ok)
-  if test "$libiconv_ok" = yes; then
-    AC_DEFINE(HAVE_GOOD_ICONV,1,[Define if you have the UNIX98 iconv functions.])
-    AC_CACHE_CHECK([whether iconv is transitive],
-      yeti_cv_lib_c_iconv_transitive,
-      if ./iconvcap iconvenc.h 2>&5; then
-        yeti_cv_lib_c_iconv_transitive=yes
-      else
-        yeti_cv_lib_c_iconv_transitive=no
-      fi)
-    if test "$yeti_cv_lib_c_iconv_transitive" = yes; then
-      AC_DEFINE(ICONV_IS_TRANSITIVE,1,[Define if iconv is transitive.])
-    else
-      AC_MSG_WARN([A non-transitive but otherwise usable iconv implementation
-                    was found.  This beast was believed to be mythical.
-                    Please send your system specs to the maintainer.])
-    fi
-  else
-    echo >iconvenc.h
-  fi
-else
-  libiconv_ok=no
-fi
 
 else
-  dnl iconv disabled by user
+  dnl libiconv (iconv) disabled by user
   libiconv_ok=no
 fi
 


### PR DESCRIPTION
# PR: Add --without-iconv configure option

## Summary
Fixes issue #21 by adding `--without-iconv` configure option to disable iconv interface.

## Problem
Users could not disable iconv support - it was always enabled if available (automagic dependency).

## Solution
- Added `--without-iconv` configure option
- Fixed incorrect documentation in README files
- Updated changelog

## Testing
| Configure Option | iconv Status |
|------------------|--------------|
| Default | ✅ Enabled |
| `--without-iconv` | ❌ Disabled |

✅ Both configurations build and pass tests