### PR TITLE
Fix autoreconf with `>=gettext-0.24`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_INIT([Enca],[1.21],[https://github.com/nijel/enca/issues])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(src/enca.c)
 AC_CONFIG_MACRO_DIR([m4])
+AM_GNU_GETTEXT([external])
+AM_GNU_GETTEXT_VERSION([0.22])
 AC_CONFIG_FILES( \
   Makefile \
   enca.spec \


### PR DESCRIPTION
Otherwise it fails with:

  `configure:18431: error: possibly undefined macro: AM_ICONV`