### PR TITLE
fix C23 compatibility for getenv/getopt prototypes

### DIFF
--- a/src/getopt.h
+++ b/src/getopt.h
@@ -144,7 +144,7 @@ struct option
    errors, only prototype getopt for the GNU C library.  */
 extern int getopt (int __argc, char *const *__argv, const char *__shortopts);
 # else /* not __GNU_LIBRARY__ */
-extern int getopt ();
+extern int getopt (int argc, char * const argv[], const char *shortopts);
 # endif /* __GNU_LIBRARY__ */
 
 # ifndef __need_getopt
@@ -161,12 +161,18 @@ extern int _getopt_internal (int __argc, char *const *__argv,
 			     int __long_only);
 # endif
 #else /* not __STDC__ */
-extern int getopt ();
+extern int getopt (int argc, char * const argv[], const char *shortopts);
 # ifndef __need_getopt
-extern int getopt_long ();
-extern int getopt_long_only ();
+extern int getopt_long (int argc, char *const *argv, const char *shortopts,
+		        const struct option *longopts, int *longind);
+extern int getopt_long_only (int argc, char *const *argv,
+			     const char *shortopts,
+		             const struct option *longopts, int *longind);
 
-extern int _getopt_internal ();
+extern int _getopt_internal (int __argc, char *const *__argv,
+			     const char *__shortopts,
+		             const struct option *__longopts, int *__longind,
+			     int __long_only);
 # endif
 #endif /* __STDC__ */
 

--- a/src/getopt_long.c
+++ b/src/getopt_long.c
@@ -199,7 +199,7 @@ static char *posixly_correct;
    whose names are inconsistent.  */
 
 #ifndef getenv
-extern char *getenv ();
+extern char *getenv (const char *name);
 #endif
 
 static char *


### PR DESCRIPTION
GCC 15 defaults to C23, which no longer supports unprototyped function declarations (K&R style). This fixes conflicts with strict prototypes in modern C libraries like musl.

Build-tested in Buildroot using musl libc and C23.

Files Modified
   1. src/getopt.h: Added full prototypes for getopt, getopt_long, getopt_long_only, and _getopt_internal to replace the old-style () declarations.
   2. src/getopt_long.c: Added the proper prototype for getenv(const char *name) instead of the unprototyped getenv().