### PR TITLE
enca: fix discard-qualifier warning in enca_eol_surface()

### DIFF
--- a/lib/guess.c
+++ b/lib/guess.c
@@ -668,7 +668,7 @@ enca_eol_surface(const unsigned char *buffer,
                  size_t size,
                  const size_t *counts)
 {
-  unsigned char *p;
+  const unsigned char *p;
   size_t i;
 
   /* Return BINARY when the sample contains some strange characters.


### PR DESCRIPTION
memchr() returns void* from a const unsigned char* buffer but was assigned to a non-const unsigned char* p, discarding the const qualifier. Change p to const unsigned char* to correctly propagate constness from the buffer parameter.