### PR TITLE
enca: fix discard-qualifier warning in is_valid_utf7()

### DIFF
--- a/lib/multibyte.c
+++ b/lib/multibyte.c
@@ -329,7 +329,7 @@ is_valid_utf7(EncaAnalyserState *analyser)
   const size_t *const counts = analyser->counts;
 
   size_t utf7count = 0; /* number of >7bit characters */
-  unsigned char *p,*q;
+  const unsigned char *p,*q;
 
   /* When the file doesn't contain enough UTF-7 shift characters,
      don't waste time scanning it. */


### PR DESCRIPTION
memchr() returns void* from a const unsigned char* buffer but was assigned to non-const unsigned char* p and q, discarding the const qualifier. Change both pointers to const unsigned char* to correctly propagate constness from the buffer parameter.